### PR TITLE
Use ephemeral ports for test app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 pids
 strongloop.json
 test/x-app
+app.port

--- a/test/app.js
+++ b/test/app.js
@@ -1,10 +1,14 @@
 'use strict';
 
+var fs = require('fs');
 var http = require('http');
+var path = require('path');
 
-var server = http.createServer().listen(3000);
+var server = http.createServer().listen(0);
 
 server.once('listening', function() {
+  var addr = JSON.stringify(this.address());
+  fs.writeFileSync(path.resolve(__dirname, 'app.port'), addr);
   console.error('args:', this.address());
 });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -3,7 +3,9 @@
 var assert = require('assert');
 var cp = require('child_process');
 var debug = require('debug')('strong-start:test');
+var fs = require('fs');
 var net = require('net');
+var path = require('path');
 var retry = require('../lib/retry');
 var slpmctl = require.resolve('strong-pm/bin/sl-pmctl');
 var slstart = require.resolve('../bin/sl-start');
@@ -41,8 +43,19 @@ function waitForApp(callback) {
 }
 
 function connectToApp(callback) {
-  debug('connect to app at 3000');
-  return connectTo(3000, callback);
+  fs.readFile(path.resolve(__dirname, 'app.port'), function(err, data) {
+    if (err) {
+      return callback(err);
+    } else {
+      try {
+        data = JSON.parse(data);
+      } catch(e) {
+        return callback(e);
+      }
+      debug('connect to app at ', data.port);
+      return connectTo(data.port, callback);
+    }
+  });
 }
 
 function connectToPm(callback) {


### PR DESCRIPTION
- Add some missing devDependencies
- Use ephemeral port for test app

I'm not sure what to do about PM's port.. I suppose the likelihood of collision during an actual test run is minimal, it's if the detached process doesn't get cleaned up.
