### PR TITLE
Fix windows

### DIFF
--- a/lib/pm.js
+++ b/lib/pm.js
@@ -13,16 +13,15 @@ var spawn = require('child_process').spawn;
 
 module.exports = Pm;
 
-
-// FIXME must add ~/.strong-pm/pmctl to the list of default pmctl sockets
-
 function Pm() {
   if (!(this instanceof Pm))
     return new Pm.apply(null, arguments);
 
   var _home = home();
-  this.base = path.join(_home, '.strong-pm');
-  this.control = path.join(this.base, 'pmctl');
+  this.base = path.resolve(_home, '.strong-pm');
+  this.control = path.resolve(this.base, 'pmctl');
+  if (process.platform === 'win32' && !/^[\/\\]{2}/.test(this.control))
+    this.control = '\\\\?\\pipe\\' + this.control;
   this.url = 'http://127.0.0.1:8701';
 }
 


### PR DESCRIPTION
On windows, local pipes can't exist on a normal filesystem.
They must be created under `\\.\pipe`.
