### PR TITLE
pm: truncate start.log before opening

### DIFF
--- a/lib/pm.js
+++ b/lib/pm.js
@@ -71,6 +71,14 @@ Pm.prototype.spawn = function(callback) {
 
   mkdirp(this.base);
 
+  try {
+    fs.truncateSync(this.logFile, 0);
+  } catch (er) {
+    // Ignore, probably the file doesn't exist, and other errors
+    // will be caught below when we open the file.
+    debug('truncate failed: %s', er.message);
+  }
+
   var logFd = fs.openSync(this.logFile, 'a');
   var options = {
     detached: true,
@@ -78,8 +86,6 @@ Pm.prototype.spawn = function(callback) {
   };
 
   debug('spawn: %s args %j options %j', process.execPath, args, options);
-
-  fs.ftruncateSync(logFd, 0);
 
   self.child = spawn(process.execPath, args, options)
     .once('error', function(err) {


### PR DESCRIPTION
Its more efficient to open once and truncate after, but Windows doesn't
support this for files opened in append mode, and we don't really care
what the order is.

connected to strongloop/strong-pm#168