### PR TITLE
Improve test reliability on CI

### DIFF
--- a/test/test-pm.js
+++ b/test/test-pm.js
@@ -15,9 +15,7 @@ tap.test('.strong-pm/pmctl is listening', function(t) {
     isAlive(function(err) {
       debug('alive? %s', err);
       t.ifError(err);
-      server.close(function() {
-        t.end();
-      });
+      server.close(t.end);
     });
   });
 });
@@ -32,58 +30,77 @@ tap.test('auto-start strong-pm', function(t) {
       t.doesNotThrow(function() {
         fs.readFileSync(pm.logFile);
       });
-      kill(function() {
-        t.end();
-      });
+      kill(t.end);
     });
   });
 });
 
 tap.test('auto-start strong-pm, twice', function(t) {
-  setup();
-
-  isAlive(function(err) {
-    debug('alive? %s', err);
-    t.assert(err);
-    start1();
-  });
-
   var log1;
   var log2;
 
-  function start1() {
-    pm.start(function(err) {
-      t.ifError(err);
-      isAlive(function(err) {
-        debug('alive? %s', err);
-        t.ifError(err);
-        t.doesNotThrow(function() {
-          t.assert((log1 = fs.readFileSync(pm.logFile, 'utf8')).length > 0);
-        });
-        start2();
-      });
+  t.test('setup', function(t) {
+    setup();
+    isAlive(function(err) {
+      debug('alive? %s', err);
+      t.assert(err, 'should be no PM running');
+      t.end();
     });
-  }
+  });
 
-  function start2() {
+  t.test('start first time', function(t) {
     pm.start(function(err) {
-      t.ifError(err);
+      t.ifError(err, 'pm should start without error');
       isAlive(function(err) {
         debug('alive? %s', err);
         t.ifError(err);
-        t.doesNotThrow(function() {
-          t.assert((log2 = fs.readFileSync(pm.logFile, 'utf8')).length > 0);
-        });
-        debug('log1 <\n%s>', log1);
-        debug('log2 <\n%s>', log2);
-        if (log1.length && log2.length)
-          t.equal(log2.substr(0, log1.length), log1, 'same pm proc, same log');
-        kill(function() {
-          t.end();
-        });
+        // ensure the app has run long enough to produce log output
+        setTimeout(t.end, 500);
       });
     });
-  }
+  });
+
+  t.test('capture log from first start', function(t) {
+    fs.readFile(pm.logFile, 'utf8', function(err, log) {
+      log1 = log;
+      t.ifErr(err, 'log file should exist');
+      t.assert(log && log.length > 0, 'log should not be empty');
+      t.end();
+    });
+  });
+
+  t.test('start second time', function(t) {
+    pm.start(function(err) {
+      t.ifError(err, 'pm should start without error');
+      isAlive(function(err) {
+        debug('alive? %s', err);
+        t.ifError(err);
+        // ensure the app has run long enough to produce log output
+        setTimeout(t.end, 250);
+      });
+    });
+  });
+
+  t.test('capture log from second start', function(t) {
+    fs.readFile(pm.logFile, 'utf8', function(err, log) {
+      log2 = log;
+      t.ifErr(err, 'log file should exist');
+      t.assert(log && log.length > 0, 'log should not be empty');
+      t.end();
+    });
+  });
+
+  t.test('compare logs and cleanup', function(t) {
+    debug('log1 <\n%s>', log1);
+    debug('log2 <\n%s>', log2);
+    t.assert(log1 && log1.length);
+    t.assert(log2 && log2.length);
+    if (log1.length && log2.length)
+      t.equal(log2.substr(0, log1.length), log1, 'same pm proc, same log');
+    kill(t.end);
+  });
+
+  t.end();
 });
 
 var dir;


### PR DESCRIPTION
Break pm start test up in to multiple sub-tests so that we can use tap's
implicit async flow control.

Once broken up, insert a delay after the first pm is started so that we
can be sure there is log output even in slower environments like CI.

Connect to strongloop-internal/scrum-nodeops#1015